### PR TITLE
fix #1 修复hibernate-jakarta-solon-plugin无法自动建表的问题,修改SessionFactory初始化时…

### DIFF
--- a/solon-jakarta-projects/solon-data/hibernate-jakarta-solon-plugin/pom.xml
+++ b/solon-jakarta-projects/solon-data/hibernate-jakarta-solon-plugin/pom.xml
@@ -22,7 +22,10 @@
             <groupId>org.noear</groupId>
             <artifactId>solon-data</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>

--- a/solon-jakarta-projects/solon-data/hibernate-jakarta-solon-plugin/src/main/java/org/hibernate/solon/integration/HibernateAdapterManager.java
+++ b/solon-jakarta-projects/solon-data/hibernate-jakarta-solon-plugin/src/main/java/org/hibernate/solon/integration/HibernateAdapterManager.java
@@ -71,6 +71,17 @@ public class HibernateAdapterManager {
         } else {
             adapter = new HibernateAdapter(bw, Solon.cfg().getProp("jpa." + bw.name()));
         }
+        // 在创建适配器时立即初始化 SessionFactory，触发建表
+        // 确保注入时 SessionFactory 已经创建
+        try {
+            adapter.getSessionFactory();
+            org.slf4j.LoggerFactory.getLogger(HibernateAdapterManager.class)
+                    .debug("Hibernate SessionFactory initialized for datasource: {}", bw.name());
+        } catch (Exception e) {
+            // 记录错误但不阻止适配器创建，因为可能后续会修复配置
+            org.slf4j.LoggerFactory.getLogger(HibernateAdapterManager.class)
+                    .error("Failed to initialize Hibernate SessionFactory for datasource: {}", bw.name(), e);
+        }
 
         return adapter;
     }

--- a/solon-jakarta-projects/solon-data/hibernate-jakarta-solon-plugin/src/test/resources/app.yml
+++ b/solon-jakarta-projects/solon-data/hibernate-jakarta-solon-plugin/src/test/resources/app.yml
@@ -41,7 +41,7 @@ jpa.test:
       dialect: org.hibernate.dialect.MySQL8Dialect
       connection:
         isolaction: 4 # 事务隔离级别 4 可重复度
-
+      physical_naming_strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy # 命名策略
 
 #默认hibernate配置
 # 可选app.yml 或者hibernate.cf.xml


### PR DESCRIPTION
### 这个PR有什么用 / 我们为什么需要它？
修复hibernate-jakarta-solon-plugin无法自动建表

### 总结您的更改
1. 修改SessionFactory初始化时机
2. test app.yml添加命名策略`physical_naming_strategy`

#### 请注明您已完成以下工作：

- [x] 确保测试通过，并在需要时添加测试覆盖率。
- [x] 确保提交消息遵循 [常规提交规范](https://www.conventionalcommits.org/) 的规则。
- [x] 考虑文档的影响，如果需要，打开一个新的文档问题或文档更改的PR。